### PR TITLE
Refactor Quoters/Delimiters and add validation logic

### DIFF
--- a/TestProject1/Test1.cs
+++ b/TestProject1/Test1.cs
@@ -22,6 +22,11 @@ public sealed class Test1
 		  Assert.IsTrue(result[1].Length == 0);
 	}
 
+	 [TestMethod]
+	 public void TestMethodSingleCommon()
+	 {
+		Assert.Throws<ArgumentException>(()=>new QuotedStringSplitter() { Delimiters = ['A','B'], Quoters=['A'] });
+	}
 
 
 	 [TestMethod]


### PR DESCRIPTION
Refactor Quoters/Delimiters and add validation logic

Refactored `Quoters` and `Delimiters` properties to use private
backing fields and added validation to prevent overlapping
characters between them. Introduced a constant error message
`CommonCharactersErrorMessage` for validation failures.

Changed `CsvDelimiters` to use `ImmutableHashSet` for immutability.
Added a new test case `TestMethodSingleCommon` to ensure validation
logic works as expected. Updated imports to include
`System.Collections.Immutable`.